### PR TITLE
Postgres dump ownership issues resolved, removed de-dupe removal

### DIFF
--- a/controllers/api/search.js
+++ b/controllers/api/search.js
@@ -32,7 +32,10 @@ router.post('/', function (req, res, next) {
         var name = "%" + req.body.name.split(' ').join("%") + "%";
 
         // Don't de-dupe if a name is specified
-        text = text.replace(" DISTINCT", "");
+        // If we remove distinct from name list, we end up with a set of
+        // the same person keyed to the same idea bc of many appointments
+        // Not sure if ideal
+        //text = text.replace(" DISTINCT", "");
 
         conditions.push('name ILIKE $' + ++paramNum);
         values.push(name);

--- a/controllers/api/search.js
+++ b/controllers/api/search.js
@@ -32,8 +32,8 @@ router.post('/', function (req, res, next) {
         var name = "%" + req.body.name.split(' ').join("%") + "%";
 
         // Don't de-dupe if a name is specified
-        // If we remove distinct from name list, we end up with a set of
-        // the same person keyed to the same idea bc of many appointments
+        // If we remove distinct from name query, we end up with redundant 
+        // results for each ID due to multiple appointments
         // Not sure if ideal
         //text = text.replace(" DISTINCT", "");
 


### PR DESCRIPTION
Line 35 controllers/api/search.js: `text = text.replace(" DISTINCT", "");`

Removing DISTINCT from query if request has a name gives us multiple results for one ID based on the number of that person's appointments, which is not ideal behavior for search. Is there another rationale for this line that I am missing? 
